### PR TITLE
Fixed the code generated by the loader

### DIFF
--- a/src/Builder/Capacity/Loader/Upsert.php
+++ b/src/Builder/Capacity/Loader/Upsert.php
@@ -149,9 +149,6 @@ final class Upsert implements Builder
                                                 ),
                                                 args: [
                                                     new Node\Arg(
-                                                        value: new Node\Expr\Variable('exception'),
-                                                    ),
-                                                    new Node\Arg(
                                                         value: new Node\Expr\Variable('line'),
                                                     ),
                                                 ],

--- a/src/Builder/Capacity/Loader/Upsert.php
+++ b/src/Builder/Capacity/Loader/Upsert.php
@@ -60,10 +60,7 @@ final class Upsert implements Builder
         }
 
         return new Node\Stmt\While_(
-            cond: new Node\Expr\Assign(
-                var: new Node\Expr\Variable(name: 'line'),
-                expr: new Node\Expr\Yield_(),
-            ),
+            cond: new Node\Expr\Variable(name: 'line'),
             stmts: [
                 new Node\Stmt\TryCatch(
                     stmts: [

--- a/src/Builder/Capacity/Loader/Upsert.php
+++ b/src/Builder/Capacity/Loader/Upsert.php
@@ -60,7 +60,7 @@ final class Upsert implements Builder
         }
 
         return new Node\Stmt\While_(
-            cond: new Node\Expr\Variable(name: 'line'),
+            cond: New Node\Expr\ConstFetch(new Node\Name('true')),
             stmts: [
                 new Node\Stmt\TryCatch(
                     stmts: [

--- a/src/Builder/Capacity/Loader/Upsert.php
+++ b/src/Builder/Capacity/Loader/Upsert.php
@@ -81,16 +81,19 @@ final class Upsert implements Builder
                             ),
                         ),
                         new Node\Stmt\Expression(
-                            expr: new Node\Expr\Yield_(
-                                value: new Node\Expr\New_(
-                                    class: new Node\Name\FullyQualified(name: 'Kiboko\\Component\\Bucket\\AcceptanceResultBucket'),
-                                    args: [
-                                        new Node\Arg(
-                                            value: new Node\Expr\Variable('line'),
-                                        ),
-                                    ],
+                            expr: new Node\Expr\Assign(
+                                var: new Node\Expr\Variable('line'),
+                                expr: new Node\Expr\Yield_(
+                                    value: new Node\Expr\New_(
+                                        class: new Node\Name\FullyQualified(name: 'Kiboko\\Component\\Bucket\\AcceptanceResultBucket'),
+                                        args: [
+                                            new Node\Arg(
+                                                value: new Node\Expr\Variable('line'),
+                                            ),
+                                        ],
+                                    ),
                                 ),
-                            ),
+                            )
                         ),
                     ],
                     catches: [
@@ -137,19 +140,22 @@ final class Upsert implements Builder
                                     ),
                                 ),
                                 new Node\Stmt\Expression(
-                                    new Node\Expr\Yield_(
-                                        value: new Node\Expr\New_(
-                                            class: new Node\Name\FullyQualified(
-                                                name: 'Kiboko\\Component\\Bucket\\RejectionResultBucket'
+                                    expr: new Node\Expr\Assign(
+                                        var: new Node\Expr\Variable('line'),
+                                        expr: new Node\Expr\Yield_(
+                                            value: new Node\Expr\New_(
+                                                class: new Node\Name\FullyQualified(
+                                                    name: 'Kiboko\\Component\\Bucket\\RejectionResultBucket'
+                                                ),
+                                                args: [
+                                                    new Node\Arg(
+                                                        value: new Node\Expr\Variable('exception'),
+                                                    ),
+                                                    new Node\Arg(
+                                                        value: new Node\Expr\Variable('line'),
+                                                    ),
+                                                ],
                                             ),
-                                            args: [
-                                                new Node\Arg(
-                                                    value: new Node\Expr\Variable('exception'),
-                                                ),
-                                                new Node\Arg(
-                                                    value: new Node\Expr\Variable('line'),
-                                                ),
-                                            ],
                                         ),
                                     ),
                                 ),

--- a/src/Builder/Loader.php
+++ b/src/Builder/Loader.php
@@ -107,6 +107,12 @@ final class Loader implements StepBuilderInterface
                                 'stmts' => [
                                     new Node\Stmt\TryCatch(
                                         stmts: [
+                                            new Node\Stmt\Expression(
+                                                new Node\Expr\Assign(
+                                                    var: new Node\Expr\Variable(name: 'line'),
+                                                    expr: new Node\Expr\Yield_(),
+                                                ),
+                                            ),
                                             $this->capacity->getNode(),
                                         ],
                                         catches: [


### PR DESCRIPTION
J'ai changé le builder du lookup pour qu'il produise ce code. 
Sinon il ne charge qu'une seule ligne.

```php
$line = yield;

try {
    while ($line) {
        try {
            $this->client->getProductModelApi()->upsert($line["identifier"], $line);
            (yield new \Kiboko\Component\Bucket\AcceptanceResultBucket($line));
        } catch (\Akeneo\Pim\ApiClient\Exception\HttpException $exception) {
            $this->logger->error($exception->getMessage(), ['exception' => $exception, 'item' => $line]);
            (yield new \Kiboko\Component\Bucket\RejectionResultBucket($exception, $line));
        }
    }
} catch (\Throwable $exception) {
    $this->logger->critical($exception->getMessage(), ['exception' => $exception]);
}