### PR TITLE
search operators with no value

### DIFF
--- a/src/Capacity/Extractor/All.php
+++ b/src/Capacity/Extractor/All.php
@@ -45,6 +45,16 @@ final class All implements Akeneo\Capacity\CapacityInterface
         'assetManager',
     ];
 
+    private static array $noValueOperators = [
+        'EMPTY',
+        'NOT EMPTY',
+        'AT LEAST COMPLETE',
+        'AT LEAST INCOMPLETE',
+        'ALL COMPLETE',
+        'ALL INCOMPLETE',
+        'UNCLASSIFIED',
+    ];
+
     public function __construct(private readonly ExpressionLanguage $interpreter)
     {
     }
@@ -61,10 +71,10 @@ final class All implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if ('EMPTY' === $filter['operator'] && \array_key_exists('value', $filter)) {
-                throw new InvalidConfigurationException('You should not provide a value for the EMPTY operator');
+            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+                throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if ('EMPTY' !== $filter['operator'] && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Extractor/All.php
+++ b/src/Capacity/Extractor/All.php
@@ -45,7 +45,7 @@ final class All implements Akeneo\Capacity\CapacityInterface
         'assetManager',
     ];
 
-    private static array $noValueOperators = [
+    private static array $unaryOperators = [
         'EMPTY',
         'NOT EMPTY',
         'AT LEAST COMPLETE',
@@ -71,10 +71,10 @@ final class All implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+            if (\in_array($filter['operator'], self::$unaryOperators, true) && \array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$unaryOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Extractor/ListPerPage.php
+++ b/src/Capacity/Extractor/ListPerPage.php
@@ -43,7 +43,7 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
         'referenceEntity',
     ];
 
-    private static array $noValueOperators = [
+    private static array $unaryOperators = [
         'EMPTY',
         'NOT EMPTY',
         'AT LEAST COMPLETE',
@@ -69,10 +69,10 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+            if (\in_array($filter['operator'], self::$unaryOperators, true) && \array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$unaryOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Extractor/ListPerPage.php
+++ b/src/Capacity/Extractor/ListPerPage.php
@@ -43,6 +43,16 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
         'referenceEntity',
     ];
 
+    private static array $noValueOperators = [
+        'EMPTY',
+        'NOT EMPTY',
+        'AT LEAST COMPLETE',
+        'AT LEAST INCOMPLETE',
+        'ALL COMPLETE',
+        'ALL INCOMPLETE',
+        'UNCLASSIFIED',
+    ];
+
     public function __construct(private readonly ExpressionLanguage $interpreter)
     {
     }
@@ -59,10 +69,10 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if ('EMPTY' === $filter['operator'] && \array_key_exists('value', $filter)) {
-                throw new InvalidConfigurationException('You should not provide a value for the EMPTY operator');
+            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+                throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if ('EMPTY' !== $filter['operator'] && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Lookup/All.php
+++ b/src/Capacity/Lookup/All.php
@@ -45,6 +45,16 @@ final class All implements Akeneo\Capacity\CapacityInterface
         'assetManager',
     ];
 
+    private static array $noValueOperators = [
+        'EMPTY',
+        'NOT EMPTY',
+        'AT LEAST COMPLETE',
+        'AT LEAST INCOMPLETE',
+        'ALL COMPLETE',
+        'ALL INCOMPLETE',
+        'UNCLASSIFIED',
+    ];
+
     public function __construct(private readonly ExpressionLanguage $interpreter)
     {
     }
@@ -61,10 +71,10 @@ final class All implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if ('EMPTY' === $filter['operator'] && \array_key_exists('value', $filter)) {
-                throw new InvalidConfigurationException('You should not provide a value for the EMPTY operator');
+            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+                throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if ('EMPTY' !== $filter['operator'] && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Lookup/All.php
+++ b/src/Capacity/Lookup/All.php
@@ -45,7 +45,7 @@ final class All implements Akeneo\Capacity\CapacityInterface
         'assetManager',
     ];
 
-    private static array $noValueOperators = [
+    private static array $unaryOperators = [
         'EMPTY',
         'NOT EMPTY',
         'AT LEAST COMPLETE',
@@ -71,10 +71,10 @@ final class All implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+            if (\in_array($filter['operator'], self::$unaryOperators, true) && \array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$unaryOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Lookup/ListPerPage.php
+++ b/src/Capacity/Lookup/ListPerPage.php
@@ -43,7 +43,7 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
         'referenceEntity',
     ];
 
-    private static array $noValueOperators = [
+    private static array $unaryOperators = [
         'EMPTY',
         'NOT EMPTY',
         'AT LEAST COMPLETE',
@@ -69,10 +69,10 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+            if (\in_array($filter['operator'], self::$unaryOperators, true) && \array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$unaryOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 

--- a/src/Capacity/Lookup/ListPerPage.php
+++ b/src/Capacity/Lookup/ListPerPage.php
@@ -43,6 +43,16 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
         'referenceEntity',
     ];
 
+    private static array $noValueOperators = [
+        'EMPTY',
+        'NOT EMPTY',
+        'AT LEAST COMPLETE',
+        'AT LEAST INCOMPLETE',
+        'ALL COMPLETE',
+        'ALL INCOMPLETE',
+        'UNCLASSIFIED',
+    ];
+
     public function __construct(private readonly ExpressionLanguage $interpreter)
     {
     }
@@ -59,10 +69,10 @@ final class ListPerPage implements Akeneo\Capacity\CapacityInterface
     {
         $builder = new Akeneo\Builder\Search();
         foreach ($filters as $filter) {
-            if ('EMPTY' === $filter['operator'] && \array_key_exists('value', $filter)) {
-                throw new InvalidConfigurationException('You should not provide a value for the EMPTY operator');
+            if (\in_array($filter['operator'], self::$noValueOperators, true) && \array_key_exists('value', $filter)) {
+                throw new InvalidConfigurationException(sprintf('You should not provide a value for the %s operator', $filter['operator']));
             }
-            if ('EMPTY' !== $filter['operator'] && !\array_key_exists('value', $filter)) {
+            if (!\in_array($filter['operator'], self::$noValueOperators, true) && !\array_key_exists('value', $filter)) {
                 throw new InvalidConfigurationException(sprintf('You should provide a value for the %s operator', $filter['operator']));
             }
 


### PR DESCRIPTION
avoids this error:
![image](https://github.com/php-etl/akeneo-plugin/assets/28787740/515f9eba-5f48-4593-a8ca-104a191ac672)
