### PR TITLE
Fixed a bug in the lookup with all method

### DIFF
--- a/src/Capacity/Lookup/All.php
+++ b/src/Capacity/Lookup/All.php
@@ -10,7 +10,6 @@ use PhpParser\Builder;
 use PhpParser\Node;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
-use function Kiboko\Component\SatelliteToolbox\Configuration\compileValue;
 use function Kiboko\Component\SatelliteToolbox\Configuration\compileValueWhenExpression;
 
 final class All implements Akeneo\Capacity\CapacityInterface
@@ -79,11 +78,11 @@ final class All implements Akeneo\Capacity\CapacityInterface
             }
 
             $builder->addFilter(
-                field: compileValue($this->interpreter, $filter['field']),
-                operator: compileValue($this->interpreter, $filter['operator']),
-                value: \array_key_exists('value', $filter) ? compileValue($this->interpreter, $filter['value']) : null,
-                scope: \array_key_exists('scope', $filter) ? compileValue($this->interpreter, $filter['scope']) : null,
-                locale: \array_key_exists('locale', $filter) ? compileValue($this->interpreter, $filter['locale']) : null
+                field: compileValueWhenExpression($this->interpreter, $filter['field']),
+                operator: compileValueWhenExpression($this->interpreter, $filter['operator']),
+                value: \array_key_exists('value', $filter) ? compileValueWhenExpression($this->interpreter, $filter['value']) : null,
+                scope: \array_key_exists('scope', $filter) ? compileValueWhenExpression($this->interpreter, $filter['scope']) : null,
+                locale: \array_key_exists('locale', $filter) ? compileValueWhenExpression($this->interpreter, $filter['locale']) : null
             );
         }
 
@@ -93,6 +92,7 @@ final class All implements Akeneo\Capacity\CapacityInterface
     public function getBuilder(array $config): Builder
     {
         $builder = (new Akeneo\Builder\Capacity\Lookup\All())
+            ->withType((string) $config['type'])
             ->withEndpoint(new Node\Identifier(sprintf('get%sApi', ucfirst((string) $config['type']))))
         ;
 
@@ -100,7 +100,7 @@ final class All implements Akeneo\Capacity\CapacityInterface
             $builder->withSearch($this->compileFilters(...$config['search']));
         }
 
-        if (\in_array($config['type'], ['attributeOption', 'assetManager']) && \array_key_exists('code', $config)) {
+        if (\in_array($config['type'], ['attributeOption', 'assetManager', 'referenceEntityRecord']) && \array_key_exists('code', $config)) {
             $builder->withCode(compileValueWhenExpression($this->interpreter, $config['code']));
         }
 


### PR DESCRIPTION
With the following configuraiton:

```yaml
              - akeneo:
                  expression_language:
                    - 'Kiboko\Component\ArrayExpressionLanguage\ArrayExpressionLanguageProvider'
                  lookup:
                    conditional:
                      - condition: '@=input["type"] == "pim_catalog_simpleselect" || input["type"] == "pim_catalog_multipleselect"'
                        type: attributeOption
                        code: '@=input["code"]'
                        method: all
                        merge:
                          map:
                            - field: '[options]'
                              expression: 'reduce(map(extractData("[code]"), lookup), join("|"))'
                      - condition: '@=input["type"] == "akeneo_reference_entity" || input["type"] == "akeneo_reference_entity_collection"'
                        type: referenceEntityRecord
                        code: '@=input["reference_data_name"]'
                        method: all
                        merge:
                          map:
                            - field: '[options]'
                              expression: 'reduce(map(extractData("[code]"), lookup), join("|"))'
                  client:
                    api_url: '@=env("AKENEO_URL")'
                    client_id: '@=env("AKENEO_CLIENT_ID")'
                    secret: '@=env("AKENEO_CLIENT_SECRET")'
                    username: '@=env("AKENEO_USERNAME")'
                    password: '@=env("AKENEO_PASSWORD")'
```

we obtain the following code:

```php
new class((new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder(getenv("AKENEO_URL")))->buildAuthenticatedByPassword(getenv("AKENEO_CLIENT_ID"), getenv("AKENEO_CLIENT_SECRET"), getenv("AKENEO_USERNAME"), getenv("AKENEO_PASSWORD")), new \Psr\Log\NullLogger()) implements \Kiboko\Contract\Pipeline\TransformerInterface
    {
        public function __construct(public \Akeneo\Pim\ApiClient\AkeneoPimClientInterface $client, public \Psr\Log\LoggerInterface $logger)
        {
        }
        public function transform() : \Generator
        {
            $input = yield;
            do {
                $bucket = new \Kiboko\Component\Bucket\ComplexResultBucket();
                $output = $input;
                if ($input["type"] == "pim_catalog_simpleselect" || $input["type"] == "pim_catalog_multipleselect") {
                    (function ($input, $bucket) use($output) {
                        $lookup = $this->client->getAttributeOptionApi()->all(queryParameters: ['search' => (new \Akeneo\Pim\ApiClient\Search\SearchBuilder())->getFilters()], attributeCode: $input["code"]);
                        $output = (function ($input) use($lookup, $output) {
                            $output = (function ($input) use($lookup, $output) {
                                $output['options'] = (function ($source) use($input) {
                                    $value = null;
                                    foreach ($source as $item) {
                                        $value = (function ($item, $value) {
                                            if (null === $item) {
                                                throw new \InvalidArgumentException('Item must not be null');
                                            }
                                            if (null === $value) {
                                                return $item;
                                            }
                                            return $value . "|" . $item;
                                        })($item, $value);
                                    }
                                    return $value;
                                })((function ($source) {
                                    foreach ($source as $item) {
                                        (yield (fn($item) => \Symfony\Component\PropertyAccess\PropertyAccess::createPropertyAccessor()->getValue($item, "[code]"))($item));
                                    }
                                })($lookup));
                                return $output;
                            })($input);
                            return $output;
                        })($input);
                        $bucket->accept($output);
                    })($input, $bucket);
                } elseif ($input["type"] == "akeneo_reference_entity" || $input["type"] == "akeneo_reference_entity_collection") {
                    (function ($input, $bucket) use($output) {
                        $lookup = $this->client->getReferenceEntityRecordApi()->all(
                            queryParameters: ['search' => (new \Akeneo\Pim\ApiClient\Search\SearchBuilder())->getFilters()],
                            referenceEntityCode: $input["reference_data_name"]
                        );
                        $output = (function ($input) use($lookup, $output) {
                            $output = (function ($input) use($lookup, $output) {
                                $output['options'] = (function ($source) use($input) {
                                    $value = null;
                                    foreach ($source as $item) {
                                        $value = (function ($item, $value) {
                                            if (null === $item) {
                                                throw new \InvalidArgumentException('Item must not be null');
                                            }
                                            if (null === $value) {
                                                return $item;
                                            }
                                            return $value . "|" . $item;
                                        })($item, $value);
                                    }
                                    return $value;
                                })((function ($source) {
                                    foreach ($source as $item) {
                                        (yield (fn($item) => \Symfony\Component\PropertyAccess\PropertyAccess::createPropertyAccessor()->getValue($item, "[code]"))($item));
                                    }
                                })($lookup));
                                return $output;
                            })($input);
                            return $output;
                        })($input);
                        $bucket->accept($output);
                    })($input, $bucket);
                } else {
                    $bucket->accept($output);
                }
            } while ($input = (yield $bucket));
        }
    }, new \Kiboko\Contract\Pipeline\NullRejection(), new \Kiboko\Contract\Pipeline\NullState()
```


